### PR TITLE
Update Android 16 support for custom kernel builds.

### DIFF
--- a/modules.bzl
+++ b/modules.bzl
@@ -80,7 +80,6 @@ _COMMON_GKI_MODULES_LIST = [
     "net/nfc/nfc.ko",
     "net/rfkill/rfkill.ko",
     "net/tipc/diag.ko",
-    "net/tipc/tipc.ko",
     "net/tls/tls.ko",
     "net/vmw_vsock/vmw_vsock_virtio_transport.ko",
 ]

--- a/modules.bzl
+++ b/modules.bzl
@@ -109,6 +109,7 @@ _X86_GKI_MODULES_LIST = [
 _X86_64_GKI_MODULES_LIST = [
     # keep sorted
     "drivers/ptp/ptp_kvm.ko",
+    "net/tipc/tipc.ko",
 ]
 
 # buildifier: disable=unnamed-macro

--- a/update_virt_prebuilts.sh
+++ b/update_virt_prebuilts.sh
@@ -31,10 +31,10 @@ for file in $(find ${GKI_PREBUILT_PATH} -maxdepth 1 -type f -printf "%f\n"); do
         cp "$@" common_dist/$file ${GKI_PREBUILT_PATH}/$file > /dev/null 2>&1
 done
 cp "$@" common_dist/${kernel_image_src} ${COMMON_PREBUILT_PATH}/${kernel_image_dst}
-test -d lib && rm -r lib
-bsdtar xvf common_dist/system_dlkm_staging_archive.tar.gz >/dev/null 2>&1
-rm -r ${COMMON_PREBUILT_PATH}/system_dlkm_staging/lib
-cp -a "$@" lib ${COMMON_PREBUILT_PATH}/system_dlkm_staging
+#test -d lib && rm -r lib
+#bsdtar xvf common_dist/system_dlkm_staging_archive.tar.gz >/dev/null 2>&1
+#rm -r ${COMMON_PREBUILT_PATH}/system_dlkm_staging/modules
+#cp -a "$@" lib/modules ${COMMON_PREBUILT_PATH}/system_dlkm_staging/modules
 cp "$@" virt_dist/{mac80211,cfg80211}.ko ${COMMON_PREBUILT_PATH}
 for file in $(find ${VIRT_PREBUILT_PATH} -maxdepth 1 -type f -printf "%f\n"); do
         cp "$@" virt_dist/$file ${VIRT_PREBUILT_PATH}/$file

--- a/update_virt_prebuilts.sh
+++ b/update_virt_prebuilts.sh
@@ -20,11 +20,15 @@ fi
 
 test -d "$ANDROID_BUILD_TOP" || (echo "ANDROID_BUILD_TOP is undefined or missing" && exit 1)
 
-COMMON_PREBUILT_PATH="$ANDROID_BUILD_TOP/kernel/prebuilts/${KERNEL_VERSION}/${ARCH}"
-VIRT_PREBUILT_PATH="$ANDROID_BUILD_TOP/kernel/prebuilts/common-modules/virtual-device/${KERNEL_VERSION}/${ARCH/_/-}"
+COMMON_PREBUILT_PATH="$ANDROID_BUILD_TOP/prebuilts/qemu-kernel/${ARCH}/${KERNEL_VERSION}"
+GKI_PREBUILT_PATH="$COMMON_PREBUILT_PATH/gki_modules"
+VIRT_PREBUILT_PATH="$COMMON_PREBUILT_PATH/goldfish_modules"
 
 for file in $(find ${COMMON_PREBUILT_PATH} -maxdepth 1 -type f -printf "%f\n"); do
         cp "$@" common_dist/$file ${COMMON_PREBUILT_PATH}/$file > /dev/null 2>&1
+done
+for file in $(find ${GKI_PREBUILT_PATH} -maxdepth 1 -type f -printf "%f\n"); do
+        cp "$@" common_dist/$file ${GKI_PREBUILT_PATH}/$file > /dev/null 2>&1
 done
 cp "$@" common_dist/${kernel_image_src} ${COMMON_PREBUILT_PATH}/${kernel_image_dst}
 test -d lib && rm -r lib


### PR DESCRIPTION
Changes for 16:

Path for copying kernel artifacts used in emulator has been updated.