### PR TITLE
tcpm_update_sink_capabilities: place port->ignore_alt_modes write inside port->lock critical region

### DIFF
--- a/drivers/usb/typec/tcpm/tcpm.c
+++ b/drivers/usb/typec/tcpm/tcpm.c
@@ -6754,7 +6754,9 @@ int tcpm_update_sink_capabilities(struct tcpm_port *port, const u32 *pdo, unsign
 {
 	// reuse tcpm_update_sink_capabilities to avoid changing ABI
 	if (nr_pdo == DO_NOT_IGNORE_ALT_MODES || nr_pdo == IGNORE_ALT_MODES) {
+		mutex_lock(&port->lock);
 		port->ignore_alt_modes = nr_pdo == IGNORE_ALT_MODES;
+		mutex_unlock(&port->lock);
 		return 0;
 	}
 


### PR DESCRIPTION
(pasted from https://github.com/GrapheneOS/kernel_common-6.6/pull/16 )
There are potential race conditions for port->ignore_alt_modes. This PR protects the write to port->ignore_alt_modes with the port->lock critical region.